### PR TITLE
Make aptmirs consumable as a Nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 /test
 /.vscode
+/result
+/result-*

--- a/README.md
+++ b/README.md
@@ -118,3 +118,23 @@ Verify operation
 ```
 ./aptmirs --config ./mirror.list --output /opt/mirror-root verify
 ```
+
+## Nix
+
+Build the package:
+
+```
+nix build
+```
+
+Run it directly from the flake:
+
+```
+nix run -- --help
+```
+
+Open a development shell with the Rust toolchain:
+
+```
+nix develop
+```

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1775710090,
+        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,92 @@
+{
+  description = "Nix flake for aptmirs";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      lib = nixpkgs.lib;
+      cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+      package = cargoToml.package;
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      forEachSupportedSystem =
+        f:
+        lib.genAttrs supportedSystems (
+          system:
+          f {
+            inherit system;
+            pkgs = import nixpkgs { inherit system; };
+          }
+        );
+    in
+    {
+      packages = forEachSupportedSystem (
+        { pkgs, ... }:
+        {
+          default = pkgs.rustPlatform.buildRustPackage {
+            pname = package.name;
+            version = package.version;
+            src = ./.;
+
+            cargoLock = {
+              lockFile = ./Cargo.lock;
+            };
+
+            nativeBuildInputs = with pkgs; [
+              pkg-config
+            ];
+
+            buildInputs = with pkgs; [
+              bzip2
+              xz
+            ];
+
+            meta = with pkgs.lib; {
+              description = package.description;
+              homepage = package.repository;
+              license = licenses.mit;
+              mainProgram = package.name;
+              platforms = platforms.unix;
+            };
+          };
+        }
+      );
+
+      apps = forEachSupportedSystem (
+        { system, ... }:
+        {
+          default = {
+            type = "app";
+            program = "${self.packages.${system}.default}/bin/${package.name}";
+          };
+        }
+      );
+
+      devShells = forEachSupportedSystem (
+        { pkgs, ... }:
+        {
+          default = pkgs.mkShell {
+            packages = with pkgs; [
+              cargo
+              clippy
+              nixpkgs-fmt
+              pkg-config
+              rust-analyzer
+              rustc
+              rustfmt
+              bzip2
+              xz
+            ];
+          };
+        }
+      );
+
+      formatter = forEachSupportedSystem ({ pkgs, ... }: pkgs.nixfmt-tree);
+    };
+}


### PR DESCRIPTION
Make aptmirs consumable as a Nix flake by adding package, app, and dev shell outputs so it can be built directly or used as an input from NixOS configurations. Use nixos-unstable by default while allowing consumers to override inputs.nixpkgs.url to build against stable releases such as nixos-25.11 or newer.

`nix flake lock --update-input nixpkgs`  updates the `flake.lock` file and `nix fmt` formats the `flake.nix` file.